### PR TITLE
Rotate console backend logs

### DIFF
--- a/console-backend-data-manager/package-version.json
+++ b/console-backend-data-manager/package-version.json
@@ -1,4 +1,4 @@
 {
 "name": "console-backend-data-manager",
-"version": "0.2.5"
+"version": "0.2.6"
 }

--- a/console-backend-utils/logger.js
+++ b/console-backend-utils/logger.js
@@ -24,21 +24,25 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 *-------------------------------------------------------------------------------*/
 
-var winston = require('winston');
+var config = require('./conf/config.json');
+var winstonlr = require('winston-logrotate');
+var rotateTransport = new winstonlr.Rotate({
+        file: config.log_file,
+        colorize: false,
+        timestamp: true,
+        level: 'info',
+        handleExceptions: true,
+        humanReadableUnhandledException: true,
+        json: true,
+        size: '10m',
+        keep: 3,
+        compress: false
+});
+
+var winston = require('winston')
 winston.emitErrs = true;
 
-var config = require('./conf/config.json');
-
-var logger = new (winston.Logger)({ exitOnError: false });
-logger.add(winston.transports.File, {
-  filename: config.log_file,
-  level: 'info',
-  timestamp: true,
-  handleExceptions: true,
-  humanReadableUnhandledException: true,
-  json: true,
-  colorize: false
-});
+var logger = new (winston.Logger)({ exitOnError: false, transports: [rotateTransport] });
 logger.add(winston.transports.Console, {
   level: 'debug',
   timestamp: true,

--- a/console-backend-utils/package.json
+++ b/console-backend-utils/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "async": "^1.5.0",
     "redis": "^2.4.2",
-    "winston": "^2.1.1"
+    "winston": "^2.1.1",
+    "winston-logrotate": "^1.0.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.4",


### PR DESCRIPTION
Use winston-logrotate to rotate the console backend log file.