### PR TITLE
PNDA-2834: Actual application status by deployment manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - PNDA-3562: Add PAM authentication
 - PNDA-3596: use passportjs for managing authentication
+- PNDA-2834: Actual application status by deployment manager
 
 ### Changed:
 - PNDA-3601: disable emailtext in Jenkins file and replace it with notifier stage and job


### PR DESCRIPTION
## Problem Statement:
PNDA-2834: Currently deployment manager providing the status based on start / stop button action in UI and it is not providing the actual status where the application was executed.

## Analysis:
- Platform-deployment-manager has three component handler
	- OOZIE
	- SPARK-STREAMING
	- JUPYTER
- Jobs will be submitted to YARN for execution
- OOZIE, YARN and SPARK-STREAMING can provide status for applications
- Need to create a python job that will query OOZIE, YARN and SPARK,
  for application's actual status

## Approach:
- Get list of application from existing “platform_applications” HBase table
- For each application get create data and calculate the total number of component present in all the applications
- Components of applications will be processed in multiprocessing environment for that process count will be calculated based on the formula below
````
                     total component count *  max  time for processing  single  component  (max 6 seconds)
Process  Count = ----------------------------------------------------------------------------------------------
                                       total time-bound( Currently 60 seconds )
````
- If calculated process count exceeds 4, set process count to 4
- Components will be processed based on its type OOZIE and SPARK STREAMING
- After components processed build aggregate status based on component's status for all application
- Once aggregate status built for all application, post it to HBase 
- Above steps will be executed in an infinite loop with an interval of 60 seconds

## Changes:
- platform-deployment-manager
  - Created a python job that will have the described approach  
  - Created a python file that will post summary data to HBase and get summary data from HBase
  - Added a new API /summary to provide summary status built for every application that will be fetched from HBase
  
  Files added:
  - platform-deployment-manager/api/src/main/resources/application_summary.py
  - platform-deployment-manager/api/src/main/resources/application_summary_registrar.py
  - platform-deployment-manager/api/src/main/resources/test_application_summary.py
  - platform-deployment-manager/api/src/main/resources/test_application_summary_registrar.py
  
  Files modified:
  - platform-deployment-manager/api/src/main/resources/app.py
  - platform-deployment-manager/api/src/main/resources/deployment-manager.py
  - platform-deployment-manager/api/src/main/resources/lifecycle-states.py
  - platform-deployment-manager/api/src/main/resources/test_deployer_manager.py
  
- platform-salt
  - Created a daemon for python job created in platform-deployment-manager
  
  Files added:
  - platform-salt/salt/deployment-manager/templates/dm-application-summary.conf.tpl
  - platform-salt/salt/deployment-manager/templates/dm-application-summary.service.tpl
  
  Files modified:
  - platform-salt/salt/deployment-manager/init.sls
  
- platform-console-backend
  - Added /summary API to get summary status from deployment manager
  
  Files modified:
  - platform-console-backend/console-backend-data-manager/routes/applications.js

## Test details:
Verified the Changes in
- UBUNTU-PICO - CDH & HDP
- UBUNTU-STD - CDH & HDP
- RHEL-PICO - CDH & HDP
- RHEL-STD - CDH & HDP
