### PR TITLE
PNDA-3626: use the secure cookie information to create an application.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - PNDA-3609: use passeport on socketio and put the secret in configuration file
+- PNDA-3626: use the secure cookie information to create an application.
 
 ## [0.4.0] 2017-06-29
 ### Added

--- a/console-backend-data-manager/routes/applications.js
+++ b/console-backend-data-manager/routes/applications.js
@@ -248,6 +248,7 @@ module.exports = function(express, logger, config, Q, HTTP, isAuthenticated) {
    * Create an application from a package
    */
   router.put('/:id', isAuthenticated, function(req, res) {
+    req.body.user = req.user;
     var applicationId = req.params.id;
     var body = JSON.stringify(req.body);
 


### PR DESCRIPTION
The username should not be extracted from insecure body information when
authentication is enabled.