### PR TITLE
Supply user.name for deploy and undeploy package APIs

### DIFF
--- a/console-backend-data-manager/README.md
+++ b/console-backend-data-manager/README.md
@@ -115,6 +115,7 @@ Example response:
 	"status": "DEPLOYED",
 	"version": "1.0.23",
 	"name": "spark-batch-example-app",
+	"user": "who-deployed-this",
 	"defaults": {
 		"oozie": {
 			"example": {

--- a/console-backend-data-manager/routes/applications.js
+++ b/console-backend-data-manager/routes/applications.js
@@ -190,7 +190,7 @@ module.exports = function(express, logger, config, Q, HTTP, isAuthenticated) {
   router.post('/:id/:action', isAuthenticated, function(req, res) {
     var applicationId = req.params.id;
     var action = req.params.action;
-    var userName = req.query.user;
+    var userName = req.query['user.name'];
 
     if (applicationId === undefined || applicationId === "" || action === undefined) {
       logger.error("Missing required key params to start or stop an application");
@@ -222,7 +222,7 @@ module.exports = function(express, logger, config, Q, HTTP, isAuthenticated) {
    */
   router.delete('/:id', isAuthenticated, function(req, res) {
     var applicationId = req.params.id;
-    var userName = req.query.user;
+    var userName = req.query['user.name'];
 
     if (applicationId === undefined || applicationId === "") {
       logger.error("Missing required key params to delete an application");
@@ -253,7 +253,7 @@ module.exports = function(express, logger, config, Q, HTTP, isAuthenticated) {
   router.put('/:id', isAuthenticated, function(req, res) {
     var applicationId = req.params.id;
     var body = JSON.stringify(req.body);
-    var userName = req.query.user;
+    var userName = req.query['user.name'];
 
     if (applicationId === undefined || applicationId === "") {
       logger.error("Missing required key params to create an application");

--- a/console-backend-data-manager/routes/packages.js
+++ b/console-backend-data-manager/routes/packages.js
@@ -240,7 +240,9 @@ module.exports = function(express, logger, config, Q, HTTP, isAuthenticated) {
    */
   router.put('/:id', isAuthenticated, function(req, res) {
     var packageId = req.params.id;
-    var deployAPI = config.deployment_manager.host + config.deployment_manager.API.packages + '/' + packageId;
+    var userName = req.query['user.name'];
+    var deployAPI = config.deployment_manager.host + config.deployment_manager.API.packages + '/' + packageId +
+      '?user.name=' + userName;
     logger.debug("packageId", packageId);
 
     if (packageId && packageId !== "") {
@@ -272,7 +274,9 @@ module.exports = function(express, logger, config, Q, HTTP, isAuthenticated) {
    */
   router.delete('/:id', isAuthenticated, function(req, res) {
     var packageId = req.params.id;
-    var deployAPI = config.deployment_manager.host + config.deployment_manager.API.packages + '/' + packageId;
+    var userName = req.query['user.name'];
+    var deployAPI = config.deployment_manager.host + config.deployment_manager.API.packages + '/' + packageId +
+      '?user.name=' + userName;
 
     if (packageId && packageId !== "") {
       logger.info("Undeploying package " + packageId + " to " + req.body.action);


### PR DESCRIPTION
Supply user.name for deploy and undeploy package APIs so the deployment manager can restrict operations on packages by user e.g. restricting undeploy to the same user that deployed the package.

PNDA-4560