### PR TITLE
Set heartbeat interval under Knox socket timeout default

### DIFF
--- a/console-backend-data-manager/app.js
+++ b/console-backend-data-manager/app.js
@@ -93,7 +93,7 @@ function onAuthorizeFail(data, message, error, accept) {
   if (error)
       accept(new Error(message));
 }
-
+io.set('heartbeat interval', 15000);
 io.use(passportSocketIo.authorize({
   store: sessionStore,
   key: 'connect.sid',


### PR DESCRIPTION
This fixes the 400/500 errors seen in the browser/Knox log (see JIRA ticket for more details)
 
PNDA-4727