### PR TITLE
PNDA-4761: Pass server time with metrics response

### DIFF
--- a/console-backend-data-manager/routes/metrics.js
+++ b/console-backend-data-manager/routes/metrics.js
@@ -45,7 +45,7 @@ module.exports = function(express, logger, config, dbManager, isAuthenticated) {
             logger.error("failed to get keys and values - " + error);
             res.json({ error: error });
           } else {
-            res.json({ metrics: response });
+            res.json({ metrics: response, servertime: Date.now().toString() });
           }
         });
     }


### PR DESCRIPTION
**Problem Statement:**
On new window for existing session, or new session, metrics reported as 'just now' even if they're very old.

**Changes Done:**
Sending server time with metrics response.

